### PR TITLE
chore: update swc_core to 10.1.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-build-wasi = "build --target wasm32-wasi"
+build-wasi = "build --target wasm32-wasip1"
 build-wasm32 = "build --target wasm32-unknown-unknown"
 
 [registries.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ strip = "symbols"
 [dependencies]
 easy-error = "1.0.0"
 serde = "1"
-swc_core = { version = "0.106.*", features = ["ecma_plugin_transform"] }
+swc_core = { version = "10.1.0", features = ["ecma_plugin_transform"] }
 tracing = { version = "0.1.40", features = ["release_max_level_off"] }
 jsx_control_statements = { path = "./transform" }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "main": "swc_plugin_jsx_control_statements.wasm",
   "scripts": {
     "prepublishOnly": "cargo build-wasi --release",
-    "prepack": "cp ./target/wasm32-wasi/release/swc_plugin_jsx_control_statements.wasm ."
+    "prepack": "cp ./target/wasm32-wasip1/release/swc_plugin_jsx_control_statements.wasm ."
   },
   "author": "intpp",
   "license": "MIT",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,5 @@ use swc_core::{
 };
 #[plugin_transform]
 pub fn process_transform(program: Program, _metadata: TransformPluginProgramMetadata) -> Program {
-    program.fold_with(&mut as_folder(visitor::JSXControlStatements))
+    program.apply(visit_mut_pass(visitor::JSXControlStatements))
 }

--- a/transform/Cargo.toml
+++ b/transform/Cargo.toml
@@ -6,10 +6,13 @@ edition = "2021"
 [dependencies]
 easy-error = "1.0.0"
 serde = "1"
-swc_common = "0.40.*"
-swc_core = { version = "0.106.*", features = ["ecma_plugin_transform"] }
+swc_common = "5.0.0"
+swc_core = { version = "10.1.0", features = ["ecma_plugin_transform"] }
 tracing = { version = "0.1.40", features = ["release_max_level_off"] }
 
 [dev-dependencies]
 testing = "0.42.0"
-swc_core = { version = "0.106.*", features = ["testing_transform", "ecma_parser"] }
+swc_core = { version = "10.1.0", features = [
+    "ecma_parser",
+    "testing_transform",
+] }

--- a/transform/tests/fixture.rs
+++ b/transform/tests/fixture.rs
@@ -2,11 +2,8 @@ use std::path::PathBuf;
 
 use swc_core::ecma::{
     parser::{EsSyntax, Syntax},
-    transforms::{
-        // base::resolver,
-        testing::{test_fixture, FixtureTestConfig},
-    },
-    visit::as_folder,
+    transforms::testing::{test_fixture, FixtureTestConfig},
+    visit::visit_mut_pass,
 };
 
 use jsx_control_statements::visitor::JSXControlStatements;
@@ -24,7 +21,7 @@ fn jsx_control_statements_fixture(input: PathBuf) {
 
     test_fixture(
         syntax(),
-        &|_| as_folder(JSXControlStatements),
+        &|_| visit_mut_pass(JSXControlStatements),
         &input,
         &output,
         FixtureTestConfig {


### PR DESCRIPTION
To upgrade the swc_core dependency to support the latest version of rspack
https://github.com/web-infra-dev/rspack/blob/main/Cargo.toml#L99