### PR TITLE
Handle hygiene problem in `For` and `With` tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,5 +17,4 @@ jobs:
         run: rustup default nightly
       - run: rustup target add wasm32-wasip1
       - run: npm install
-      - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
       - run: npm publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [ published ]
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -16,5 +20,9 @@ jobs:
       - name: Night toolchain
         run: rustup default nightly
       - run: rustup target add wasm32-wasip1
+
+      # Ensure npm 11.5.1 or later is installed
+      - name: Update npm
+        run: npm install -g npm@latest
       - run: npm install
       - run: npm publish

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ lto = true
 strip = "symbols"
 
 [dependencies]
-swc_core = { version = "10.6.1", features = ["ecma_plugin_transform"] }
+swc_core = { version = "40.0.0", features = ["ecma_plugin_transform"] }
 jsx_control_statements = { path = "./transform" }

--- a/transform/Cargo.toml
+++ b/transform/Cargo.toml
@@ -4,13 +4,12 @@ version = "0.7.1"
 edition = "2021"
 
 [dependencies]
-swc_common = "5.0.0"
-swc_core = { version = "10.6.1", features = ["ecma_plugin_transform"] }
+swc_core = { version = "40.0.0", features = ["ecma_plugin_transform"] }
 tracing = { version = "0.1.40", features = ["release_max_level_off"] }
 
 [dev-dependencies]
-testing = "0.42.0"
-swc_core = { version = "10.6.1", features = [
+testing = "18.0.0"
+swc_core = { version = "40.0.0", features = [
     "ecma_parser",
     "testing_transform",
 ] }

--- a/transform/src/tags/for_tag.rs
+++ b/transform/src/tags/for_tag.rs
@@ -1,7 +1,7 @@
-use swc_common::{SyntaxContext, DUMMY_SP};
 use swc_core::atoms::Atom;
 use swc_core::ecma::ast::JSXElement;
 use swc_core::ecma::ast::*;
+use swc_core::common::{DUMMY_SP, SyntaxContext};
 
 use crate::utils::attributes::{
     get_for_jsx_element_attributes_expr, get_for_jsx_element_attributes_ident, get_key_attribute,

--- a/transform/src/tags/for_tag.rs
+++ b/transform/src/tags/for_tag.rs
@@ -1,26 +1,70 @@
 use swc_core::atoms::Atom;
+use swc_core::common::{SyntaxContext, DUMMY_SP};
 use swc_core::ecma::ast::JSXElement;
 use swc_core::ecma::ast::*;
-use swc_core::common::{DUMMY_SP, SyntaxContext};
+use swc_core::ecma::visit::VisitMutWith;
 
 use crate::utils::attributes::{
     get_for_jsx_element_attributes_expr, get_for_jsx_element_attributes_ident, get_key_attribute,
 };
 use crate::utils::elements::convert_children_to_expression;
+use crate::utils::ident_replacer::IdentReplacer;
 
 pub fn convert_jsx_element(jsx_element: &mut JSXElement) -> Expr {
-    let (of_expr, body_expr, params) = parse_for_jsx_element(jsx_element.clone());
-
+    let (of_expr, body_expr, each_ident, index_ident) = parse_for_jsx_element(jsx_element.clone());
     let group_key = get_key_attribute(jsx_element);
-    let children_expr =
+    let mut children_expr =
         convert_children_to_expression(&mut jsx_element.children, group_key.clone());
 
-    let mut map_args_fn = ExprOrSpread {
+    // use valid body expression and return
+    if body_expr != Expr::Invalid(Invalid { span: DUMMY_SP }) {
+        let map_args_fn = ExprOrSpread {
+            spread: None,
+            expr: Box::new(body_expr),
+        };
+        return get_call_expr(map_args_fn, &of_expr);
+    }
+
+    if children_expr == Expr::Lit(Lit::Null(Null { span: DUMMY_SP })) {
+        return Expr::Lit(Lit::Null(Null { span: DUMMY_SP }));
+    }
+
+    // use children, make ident ctxt same as `each`, `index`
+    let mut replacer = IdentReplacer {
+        target_sym: each_ident.sym.clone(),
+        target_ctxt: each_ident.ctxt,
+    };
+    children_expr.visit_mut_with(&mut replacer);
+
+    let mut idx_replacer = IdentReplacer {
+        target_sym: index_ident.sym.clone(),
+        target_ctxt: index_ident.ctxt,
+    };
+    children_expr.visit_mut_with(&mut idx_replacer);
+
+    let map_args_fn = ExprOrSpread {
         spread: None,
         expr: Box::new(Expr::Fn(FnExpr {
             ident: Default::default(),
             function: Box::new(Function {
-                params,
+                params: vec![
+                    Param {
+                        span: DUMMY_SP,
+                        decorators: Default::default(),
+                        pat: Pat::Ident(BindingIdent {
+                            id: each_ident,
+                            type_ann: Default::default(),
+                        }),
+                    },
+                    Param {
+                        span: DUMMY_SP,
+                        decorators: Default::default(),
+                        pat: Pat::Ident(BindingIdent {
+                            id: index_ident,
+                            type_ann: Default::default(),
+                        }),
+                    },
+                ],
                 decorators: Default::default(),
                 span: DUMMY_SP,
                 ctxt: SyntaxContext::empty(),
@@ -40,24 +84,10 @@ pub fn convert_jsx_element(jsx_element: &mut JSXElement) -> Expr {
         })),
     };
 
-    let mut expr = get_call_expr(map_args_fn, &of_expr);
-
-    if body_expr != Expr::Invalid(Invalid { span: DUMMY_SP }) {
-        map_args_fn = ExprOrSpread {
-            spread: None,
-            expr: Box::new(body_expr),
-        };
-        expr = get_call_expr(map_args_fn, &of_expr);
-    } else if children_expr == Expr::Lit(Lit::Null(Null { span: DUMMY_SP })) {
-        expr = Expr::Lit(Lit::Null(Null { span: DUMMY_SP }));
-    }
-
-    expr
+    get_call_expr(map_args_fn, &of_expr)
 }
 
-pub fn parse_for_jsx_element(jsx_element: JSXElement) -> (Expr, Expr, Vec<Param>) {
-    let mut params = Vec::new();
-
+pub fn parse_for_jsx_element(jsx_element: JSXElement) -> (Expr, Expr, Ident, Ident) {
     let each_ident = get_for_jsx_element_attributes_ident(&jsx_element, "each");
     let index_ident = get_for_jsx_element_attributes_ident(&jsx_element, "index");
     let mut of_expr = get_for_jsx_element_attributes_expr(&jsx_element, "of");
@@ -67,23 +97,7 @@ pub fn parse_for_jsx_element(jsx_element: JSXElement) -> (Expr, Expr, Vec<Param>
         of_expr = Expr::Ident(Ident::from(Atom::from("[]")));
     }
 
-    params.push(Param {
-        span: DUMMY_SP,
-        decorators: Default::default(),
-        pat: Pat::Ident(BindingIdent {
-            id: each_ident,
-            type_ann: Default::default(),
-        }),
-    });
-    params.push(Param {
-        span: DUMMY_SP,
-        decorators: Default::default(),
-        pat: Pat::Ident(BindingIdent {
-            id: index_ident,
-            type_ann: Default::default(),
-        }),
-    });
-    (of_expr, body_expr, params)
+    (of_expr, body_expr, each_ident, index_ident)
 }
 
 fn get_call_expr(map_args_fn: ExprOrSpread, of_expr: &Expr) -> Expr {

--- a/transform/src/tags/for_tag.rs
+++ b/transform/src/tags/for_tag.rs
@@ -11,7 +11,7 @@ use crate::utils::elements::convert_children_to_expression;
 use crate::utils::ident_replacer::IdentReplacer;
 
 pub fn convert_jsx_element(jsx_element: &mut JSXElement) -> Expr {
-    let (of_expr, body_expr, each_ident, index_ident) = parse_for_jsx_element(jsx_element.clone());
+    let (of_expr, body_expr, for_idents) = parse_for_jsx_element(jsx_element.clone());
     let group_key = get_key_attribute(jsx_element);
     let mut children_expr =
         convert_children_to_expression(&mut jsx_element.children, group_key.clone());
@@ -30,41 +30,37 @@ pub fn convert_jsx_element(jsx_element: &mut JSXElement) -> Expr {
     }
 
     // use children, make ident ctxt same as `each`, `index`
-    let mut replacer = IdentReplacer {
-        target_sym: each_ident.sym.clone(),
-        target_ctxt: each_ident.ctxt,
-    };
-    children_expr.visit_mut_with(&mut replacer);
+    for ident in &for_idents {
+        if let Some(ident) = ident {
+            let mut replacer = IdentReplacer {
+                target_sym: ident.sym.clone(),
+                target_ctxt: ident.ctxt,
+            };
+            children_expr.visit_mut_with(&mut replacer);
+        }
+    }
 
-    let mut idx_replacer = IdentReplacer {
-        target_sym: index_ident.sym.clone(),
-        target_ctxt: index_ident.ctxt,
-    };
-    children_expr.visit_mut_with(&mut idx_replacer);
-
+    let params = for_idents
+        .into_iter()
+        .map(|ident| Param {
+            span: DUMMY_SP,
+            decorators: Default::default(),
+            pat: Pat::Ident(BindingIdent {
+                id: if ident.is_some() {
+                    ident.unwrap()
+                } else {
+                    Ident::from("_")
+                },
+                type_ann: Default::default(),
+            }),
+        })
+        .collect();
     let map_args_fn = ExprOrSpread {
         spread: None,
         expr: Box::new(Expr::Fn(FnExpr {
             ident: Default::default(),
             function: Box::new(Function {
-                params: vec![
-                    Param {
-                        span: DUMMY_SP,
-                        decorators: Default::default(),
-                        pat: Pat::Ident(BindingIdent {
-                            id: each_ident,
-                            type_ann: Default::default(),
-                        }),
-                    },
-                    Param {
-                        span: DUMMY_SP,
-                        decorators: Default::default(),
-                        pat: Pat::Ident(BindingIdent {
-                            id: index_ident,
-                            type_ann: Default::default(),
-                        }),
-                    },
-                ],
+                params,
                 decorators: Default::default(),
                 span: DUMMY_SP,
                 ctxt: SyntaxContext::empty(),
@@ -87,7 +83,7 @@ pub fn convert_jsx_element(jsx_element: &mut JSXElement) -> Expr {
     get_call_expr(map_args_fn, &of_expr)
 }
 
-pub fn parse_for_jsx_element(jsx_element: JSXElement) -> (Expr, Expr, Ident, Ident) {
+fn parse_for_jsx_element(jsx_element: JSXElement) -> (Expr, Expr, Vec<Option<Ident>>) {
     let each_ident = get_for_jsx_element_attributes_ident(&jsx_element, "each");
     let index_ident = get_for_jsx_element_attributes_ident(&jsx_element, "index");
     let mut of_expr = get_for_jsx_element_attributes_expr(&jsx_element, "of");
@@ -97,7 +93,9 @@ pub fn parse_for_jsx_element(jsx_element: JSXElement) -> (Expr, Expr, Ident, Ide
         of_expr = Expr::Ident(Ident::from(Atom::from("[]")));
     }
 
-    (of_expr, body_expr, each_ident, index_ident)
+    let idents = vec![each_ident, index_ident];
+
+    (of_expr, body_expr, idents)
 }
 
 fn get_call_expr(map_args_fn: ExprOrSpread, of_expr: &Expr) -> Expr {

--- a/transform/src/tags/with_tag.rs
+++ b/transform/src/tags/with_tag.rs
@@ -1,21 +1,40 @@
 use swc_core::atoms::Atom;
-use swc_core::common::{DUMMY_SP, Spanned, SyntaxContext};
+use swc_core::common::{Spanned, SyntaxContext, DUMMY_SP};
 use swc_core::ecma::ast::JSXElement;
 use swc_core::ecma::ast::*;
+use swc_core::ecma::visit::VisitMutWith;
 
 use crate::utils::attributes::get_key_attribute;
 use crate::utils::elements::convert_children_to_expression;
 
+use crate::utils::ident_replacer::IdentReplacer;
 use crate::utils::playthings::display_error;
 
 pub fn convert_jsx_element(jsx_element: &mut JSXElement) -> Expr {
-    let (params, values, ctxt) = parse_with_jsx_element(jsx_element);
+    let (param_idents, values, ctxt) = parse_with_jsx_element(jsx_element);
 
     let group_key = get_key_attribute(jsx_element);
 
-    let children_expr =
+    let mut children_expr =
         convert_children_to_expression(&mut jsx_element.children, group_key.clone());
 
+    for param_ident in &param_idents {
+        let mut replacer = IdentReplacer {
+            target_sym: param_ident.sym.clone(),
+            target_ctxt: param_ident.ctxt,
+        };
+        children_expr.visit_mut_with(&mut replacer);
+    }
+
+    let params = param_idents
+        .into_iter()
+        .map(|ident| {
+            Param::from(Pat::Ident(BindingIdent {
+                id: ident,
+                type_ann: None,
+            }))
+        })
+        .collect();
     Expr::Call(CallExpr {
         span: DUMMY_SP,
         ctxt,
@@ -56,8 +75,8 @@ pub fn convert_jsx_element(jsx_element: &mut JSXElement) -> Expr {
 
 pub fn parse_with_jsx_element(
     jsx_element: &mut JSXElement,
-) -> (Vec<Param>, Vec<ExprOrSpread>, SyntaxContext) {
-    let mut params = Vec::new();
+) -> (Vec<Ident>, Vec<ExprOrSpread>, SyntaxContext) {
+    let mut param_idents = Vec::new();
     let mut values = Vec::new();
 
     let ctxt = SyntaxContext::empty();
@@ -69,15 +88,12 @@ pub fn parse_with_jsx_element(
         .for_each(|attribute| match attribute {
             JSXAttrOrSpread::JSXAttr(JSXAttr { name, value, .. }) => {
                 if let JSXAttrName::Ident(IdentName { sym, .. }) = name {
-                    params.push(Param::from(Pat::Ident(BindingIdent {
-                        id: Ident {
-                            span: DUMMY_SP,
-                            sym: sym.clone(),
-                            ctxt,
-                            optional: false,
-                        },
-                        type_ann: None,
-                    })));
+                    param_idents.push(Ident {
+                        span: DUMMY_SP,
+                        sym: sym.clone(),
+                        ctxt,
+                        optional: false,
+                    });
                 }
 
                 if let JSXAttrName::JSXNamespacedName(JSXNamespacedName {
@@ -125,5 +141,5 @@ pub fn parse_with_jsx_element(
         ExprOrSpread::from(Box::new(Expr::This(ThisExpr { span: DUMMY_SP }))),
     );
 
-    (params, values, ctxt)
+    (param_idents, values, ctxt)
 }

--- a/transform/src/tags/with_tag.rs
+++ b/transform/src/tags/with_tag.rs
@@ -1,6 +1,5 @@
-use swc_common::{SyntaxContext, DUMMY_SP};
 use swc_core::atoms::Atom;
-use swc_core::common::Spanned;
+use swc_core::common::{DUMMY_SP, Spanned, SyntaxContext};
 use swc_core::ecma::ast::JSXElement;
 use swc_core::ecma::ast::*;
 

--- a/transform/src/utils/attributes.rs
+++ b/transform/src/utils/attributes.rs
@@ -289,7 +289,7 @@ pub fn get_for_jsx_element_attributes_expr(jsx_element: &JSXElement, attr_name: 
         .unwrap_or(Expr::Invalid(Invalid { span: DUMMY_SP }))
 }
 
-pub fn get_for_jsx_element_attributes_ident(jsx_element: &JSXElement, attr_name: &str) -> Ident {
+pub fn get_for_jsx_element_attributes_ident(jsx_element: &JSXElement, attr_name: &str) -> Option<Ident> {
     let ctxt = SyntaxContext::empty();
 
 
@@ -298,16 +298,16 @@ pub fn get_for_jsx_element_attributes_ident(jsx_element: &JSXElement, attr_name:
             JSXAttrOrSpread::JSXAttr(JSXAttr { value, .. }) => match value {
                 Some(JSXAttrValue::Lit(Lit::Str(value))) => {
                     let sym = value.value;
-                    Ident {
+                    Some(Ident {
                         span: DUMMY_SP,
                         sym,
                         ctxt,
                         optional: Default::default(),
-                    }
+                    })
                 }
                 _ => {
                     throw_not_string_type(jsx_element, attr_name);
-                    Ident::from("_")
+                    None
                 }
             },
             JSXAttrOrSpread::SpreadElement(value) => {
@@ -316,8 +316,8 @@ pub fn get_for_jsx_element_attributes_ident(jsx_element: &JSXElement, attr_name:
                     format!("Spread is invalid for the value of a {}!", attr_name).as_str(),
                 );
 
-                Ident::from("_")
+                None
             }
         })
-        .unwrap_or(Ident::from("_"))
+        .unwrap_or(None)
 }

--- a/transform/src/utils/attributes.rs
+++ b/transform/src/utils/attributes.rs
@@ -8,7 +8,6 @@ use swc_core::ecma::ast::{
 };
 use tracing::debug;
 
-use crate::utils::elements::find_first_ident_ctxt_in_jsx_element;
 use crate::utils::playthings::display_error;
 
 pub fn build_key_attribute_value(group: &String, index: usize) -> String {
@@ -293,13 +292,12 @@ pub fn get_for_jsx_element_attributes_expr(jsx_element: &JSXElement, attr_name: 
 pub fn get_for_jsx_element_attributes_ident(jsx_element: &JSXElement, attr_name: &str) -> Ident {
     let ctxt = SyntaxContext::empty();
 
+
     get_jsx_element_attribute(jsx_element, attr_name)
         .map(|attr| match attr {
             JSXAttrOrSpread::JSXAttr(JSXAttr { value, .. }) => match value {
                 Some(JSXAttrValue::Lit(Lit::Str(value))) => {
                     let sym = value.value;
-                    let ctxt = find_first_ident_ctxt_in_jsx_element(&jsx_element, &sym).unwrap_or(ctxt);
-
                     Ident {
                         span: DUMMY_SP,
                         sym,

--- a/transform/src/utils/attributes.rs
+++ b/transform/src/utils/attributes.rs
@@ -1,6 +1,6 @@
-use swc_common::SyntaxContext;
 use swc_core::common::Spanned;
 use swc_core::common::DUMMY_SP;
+use swc_core::common::SyntaxContext;
 use swc_core::ecma::ast::{
     ArrayLit, CondExpr, Expr, ExprOrSpread, Ident, IdentName, Invalid, JSXAttr, JSXAttrName,
     JSXAttrOrSpread, JSXAttrValue, JSXElement, JSXElementChild, JSXElementName, JSXExpr,
@@ -8,6 +8,7 @@ use swc_core::ecma::ast::{
 };
 use tracing::debug;
 
+use crate::utils::elements::find_first_ident_ctxt_in_jsx_element;
 use crate::utils::playthings::display_error;
 
 pub fn build_key_attribute_value(group: &String, index: usize) -> String {
@@ -297,6 +298,7 @@ pub fn get_for_jsx_element_attributes_ident(jsx_element: &JSXElement, attr_name:
             JSXAttrOrSpread::JSXAttr(JSXAttr { value, .. }) => match value {
                 Some(JSXAttrValue::Lit(Lit::Str(value))) => {
                     let sym = value.value;
+                    let ctxt = find_first_ident_ctxt_in_jsx_element(&jsx_element, &sym).unwrap_or(ctxt);
 
                     Ident {
                         span: DUMMY_SP,

--- a/transform/src/utils/elements.rs
+++ b/transform/src/utils/elements.rs
@@ -1,10 +1,8 @@
-use swc_core::atoms::Atom;
-use swc_core::common::{SyntaxContext, DUMMY_SP};
+use swc_core::common::DUMMY_SP;
 use swc_core::ecma::ast::{
-    ArrayLit, Expr, ExprOrSpread, JSXElement, JSXElementChild, JSXExpr, JSXExprContainer, JSXText,
+    ArrayLit, Expr, ExprOrSpread, JSXElementChild, JSXExpr, JSXExprContainer, JSXText,
     Lit, Null, Str,
 };
-use swc_core::ecma::visit::{Visit, VisitWith};
 use tracing::debug;
 
 use crate::utils::attributes::{build_key_attribute_value, set_jsx_child_element_key_attribute};
@@ -92,80 +90,4 @@ pub fn wrap_by_child_jsx_expr_container(expr: Expr) -> JSXElementChild {
         span: DUMMY_SP,
         expr: JSXExpr::Expr(Box::new(expr)),
     })
-}
-
-/// date: 2025-11-06
-///
-/// TODO: 💥 This is not perfect yet.
-///
-/// finding ctxt to reuse, when use this plugin in rspack, the ident name in `For` will be renamed.
-///
-/// can resolve this:
-/// ```jsx
-/// // input.js
-/// <For each="item" index="idx" of={list}>
-///     <div>{item.xxx}</div>
-/// </For>
-///
-/// // output.js
-/// list.map(function(item1) { // ✅ <-- after using find_first_ident_ctxt_in_jsx_element this will be corrected
-///     return item.xxx; // cause undefined error
-/// })
-/// ```
-///
-/// But this is still issue:
-///
-/// ```jsx
-/// // input.js
-/// <For each="item" index="idx" of={list}>
-/// {((item2) => {
-///     return item.xxx;
-/// })()}
-/// </For>
-///
-/// // output.js
-/// list.map(function(item1, idx) { // 💥 <-- still issue
-///     return function(item2) {
-///         return item.xxx; // 💥 <-- still issue
-///     }();
-/// }, _this)
-/// ```
-pub fn find_first_ident_ctxt_in_jsx_element(
-    jsx: &JSXElement,
-    target: &Atom,
-) -> Option<SyntaxContext> {
-    let mut v = FindIdentCtxt {
-        target,
-        found: None,
-    };
-    jsx.visit_with(&mut v);
-    v.found
-}
-
-pub struct FindIdentCtxt<'a> {
-    target: &'a Atom,
-    found: Option<SyntaxContext>,
-}
-
-impl<'a> Visit for FindIdentCtxt<'a> {
-    fn visit_expr(&mut self, expr: &Expr) {
-        // skip if found
-        if self.found.is_some() {
-            return;
-        }
-
-        if let Expr::Ident(id) = expr {
-            if &id.sym == self.target {
-                self.found = Some(id.ctxt);
-                return;
-            }
-        }
-
-        expr.visit_children_with(self);
-    }
-
-    /// avoid ident in callee
-    fn visit_callee(&mut self, _node: &swc_core::ecma::ast::Callee) {
-        return;
-    }
 }

--- a/transform/src/utils/elements.rs
+++ b/transform/src/utils/elements.rs
@@ -1,8 +1,10 @@
-use swc_core::common::DUMMY_SP;
+use swc_core::atoms::Atom;
+use swc_core::common::{SyntaxContext, DUMMY_SP};
 use swc_core::ecma::ast::{
-    ArrayLit, Expr, ExprOrSpread, JSXElementChild, JSXExpr, JSXExprContainer, JSXText, Lit, Null,
-    Str,
+    ArrayLit, Expr, ExprOrSpread, JSXElement, JSXElementChild, JSXExpr, JSXExprContainer, JSXText,
+    Lit, Null, Str,
 };
+use swc_core::ecma::visit::{Visit, VisitWith};
 use tracing::debug;
 
 use crate::utils::attributes::{build_key_attribute_value, set_jsx_child_element_key_attribute};
@@ -90,4 +92,80 @@ pub fn wrap_by_child_jsx_expr_container(expr: Expr) -> JSXElementChild {
         span: DUMMY_SP,
         expr: JSXExpr::Expr(Box::new(expr)),
     })
+}
+
+/// date: 2025-11-06
+///
+/// TODO: 💥 This is not perfect yet.
+///
+/// finding ctxt to reuse, when use this plugin in rspack, the ident name in `For` will be renamed.
+///
+/// can resolve this:
+/// ```jsx
+/// // input.js
+/// <For each="item" index="idx" of={list}>
+///     <div>{item.xxx}</div>
+/// </For>
+///
+/// // output.js
+/// list.map(function(item1) { // ✅ <-- after using find_first_ident_ctxt_in_jsx_element this will be corrected
+///     return item.xxx; // cause undefined error
+/// })
+/// ```
+///
+/// But this is still issue:
+///
+/// ```jsx
+/// // input.js
+/// <For each="item" index="idx" of={list}>
+/// {((item2) => {
+///     return item.xxx;
+/// })()}
+/// </For>
+///
+/// // output.js
+/// list.map(function(item1, idx) { // 💥 <-- still issue
+///     return function(item2) {
+///         return item.xxx; // 💥 <-- still issue
+///     }();
+/// }, _this)
+/// ```
+pub fn find_first_ident_ctxt_in_jsx_element(
+    jsx: &JSXElement,
+    target: &Atom,
+) -> Option<SyntaxContext> {
+    let mut v = FindIdentCtxt {
+        target,
+        found: None,
+    };
+    jsx.visit_with(&mut v);
+    v.found
+}
+
+pub struct FindIdentCtxt<'a> {
+    target: &'a Atom,
+    found: Option<SyntaxContext>,
+}
+
+impl<'a> Visit for FindIdentCtxt<'a> {
+    fn visit_expr(&mut self, expr: &Expr) {
+        // skip if found
+        if self.found.is_some() {
+            return;
+        }
+
+        if let Expr::Ident(id) = expr {
+            if &id.sym == self.target {
+                self.found = Some(id.ctxt);
+                return;
+            }
+        }
+
+        expr.visit_children_with(self);
+    }
+
+    /// avoid ident in callee
+    fn visit_callee(&mut self, _node: &swc_core::ecma::ast::Callee) {
+        return;
+    }
 }

--- a/transform/src/utils/ident_replacer.rs
+++ b/transform/src/utils/ident_replacer.rs
@@ -1,0 +1,81 @@
+use swc_core::{
+    atoms::Atom,
+    common::SyntaxContext,
+    ecma::{
+        ast::{
+            ClassMethod, ClassProp, Ident, KeyValueProp, MemberExpr, MemberProp, PropName,
+            VarDeclarator,
+        },
+        visit::{VisitMut, VisitMutWith},
+    },
+};
+
+/// to keep ident same ctxt as `each`, `index` in `<For>` tag.
+pub struct IdentReplacer {
+    pub target_sym: Atom,
+    pub target_ctxt: SyntaxContext,
+}
+
+impl VisitMut for IdentReplacer {
+    // make same ctxt
+    fn visit_mut_ident(&mut self, node: &mut Ident) {
+        if node.sym == self.target_sym {
+            node.ctxt = self.target_ctxt;
+        }
+        node.visit_mut_children_with(self);
+    }
+
+    // exclude MemberExpr (obj.item)
+    fn visit_mut_member_expr(&mut self, node: &mut MemberExpr) {
+        // visit object parts (e.g `this.props` in this.props.list)
+        node.obj.visit_mut_with(self);
+
+        // only key of Compuetd
+        if let MemberProp::Computed(c) = &mut node.prop {
+            c.visit_mut_with(self);
+        }
+
+        // no need to visit MemberProp::Ident
+    }
+
+    // exclude Object KeyValue ({ item: value })
+    fn visit_mut_key_value_prop(&mut self, node: &mut KeyValueProp) {
+        // visit value
+        node.value.visit_mut_with(self);
+
+        // only key of Compuetd
+        if let PropName::Computed(c) = &mut node.key {
+            c.visit_mut_with(self);
+        }
+        // no need to visit MemberProp::Ident
+    }
+
+    // exclude class { item() {} }
+    fn visit_mut_class_method(&mut self, n: &mut ClassMethod) {
+        // visit function body
+        n.function.visit_mut_with(self);
+
+        // like KeyValue, but only key of Compuetd
+        if let PropName::Computed(c) = &mut n.key {
+            c.visit_mut_with(self);
+        }
+        // no need to visit MemberProp::Ident
+    }
+
+    // exclude class { item = 1 }
+    fn visit_mut_class_prop(&mut self, n: &mut ClassProp) {
+        n.value.visit_mut_with(self);
+
+        if let PropName::Computed(c) = &mut n.key {
+            c.visit_mut_with(self);
+        }
+        // no need to visit MemberProp::Ident
+    }
+
+    // exclude const item = xxx
+    fn visit_mut_var_declarator(&mut self, node: &mut VarDeclarator) {
+        // ignore `id`, only init
+        node.init.visit_mut_with(self);
+    }
+}
+

--- a/transform/src/utils/mod.rs
+++ b/transform/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod attributes;
 pub mod elements;
+pub mod ident_replacer;
 pub mod playthings;

--- a/transform/tests/fixture.rs
+++ b/transform/tests/fixture.rs
@@ -1,7 +1,10 @@
 use std::path::PathBuf;
 
+use swc_core::common::Mark;
 use swc_core::ecma::{
+    ast::Pass,
     parser::{EsSyntax, Syntax},
+    transforms::base::resolver,
     transforms::testing::{test_fixture, FixtureTestConfig},
     visit::visit_mut_pass,
 };
@@ -15,13 +18,22 @@ fn syntax() -> Syntax {
     })
 }
 
+// https://swc.rs/docs/plugin/ecmascript/cheatsheet#apply-resolver-while-testing
+fn tr() -> impl Pass {
+    (
+        resolver(Mark::new(), Mark::new(), false),
+        // Most of transform does not care about globals so it does not need `SyntaxContext`
+        visit_mut_pass(JSXControlStatements),
+    )
+}
+
 #[testing::fixture("tests/fixture/**/input.js")]
 fn jsx_control_statements_fixture(input: PathBuf) {
     let output = input.parent().unwrap().join("output.js");
 
     test_fixture(
         syntax(),
-        &|_| visit_mut_pass(JSXControlStatements),
+        &|_| tr(),
         &input,
         &output,
         FixtureTestConfig {

--- a/transform/tests/fixture/for-complex-ctxt/input.js
+++ b/transform/tests/fixture/for-complex-ctxt/input.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+export class Component extends React.Component {
+  render() {
+    return (
+      <For each="item" index="index" of={this.props.list}>
+        <div>
+          {this.renderContent({
+            index,
+            item,
+          })}
+          {this.renderContent2(item)}
+          {(() => {
+            const item = index + 1;
+            return [item]
+          })()}
+          {(() => {
+            // should be ignored
+            this.obj.item;
+            class A {
+              item() {}
+            }
+            class B {
+              item = 1;
+            }
+
+            // should be same ctxt
+            this.obj[item];
+            const b = item + 1;
+            const c = { [item]: 2 };
+            return [new A(), new B(), b, c];
+          })()}
+        </div>
+      </For>
+    );
+  }
+}

--- a/transform/tests/fixture/for-complex-ctxt/output.js
+++ b/transform/tests/fixture/for-complex-ctxt/output.js
@@ -1,0 +1,42 @@
+import React from 'react';
+export class Component extends React.Component {
+    render() {
+        return this.props.list.map(function(item, index) {
+            return <div>
+          {this.renderContent({
+                index,
+                item
+            })}
+          {this.renderContent2(item)}
+          {(()=>{
+                const item1 = index + 1;
+                return [
+                    item
+                ];
+            })()}
+          {(()=>{
+                // should be ignored
+                this.obj.item;
+                class A {
+                    item() {}
+                }
+                class B {
+                    item = 1;
+                }
+                // should be same ctxt
+                this.obj[item];
+                const b = item + 1;
+                const c = {
+                    [item]: 2
+                };
+                return [
+                    new A(),
+                    new B(),
+                    b,
+                    c
+                ];
+            })()}
+        </div>;
+        }, this);
+    }
+}

--- a/transform/tests/fixture/for-without-each/input.js
+++ b/transform/tests/fixture/for-without-each/input.js
@@ -11,3 +11,12 @@ module.exports = class extends React.Component {
     );
   }
 };
+
+module.exports.A = () => {
+  const _ = 1;
+  return (
+    <div>
+      <For of={[1, 2, 3]}>ABC{_}</For>
+    </div>
+  );
+};

--- a/transform/tests/fixture/for-without-each/output.js
+++ b/transform/tests/fixture/for-without-each/output.js
@@ -12,3 +12,18 @@ module.exports = class extends React.Component {
       </div>;
     }
 };
+module.exports.A = ()=>{
+    const _1 = 1;
+    return <div>
+      {[
+        1,
+        2,
+        3
+    ].map(function(_, _) {
+        return [
+            "ABC",
+            _1
+        ];
+    }, this)}
+    </div>;
+};

--- a/transform/tests/fixture/for/input.js
+++ b/transform/tests/fixture/for/input.js
@@ -3,7 +3,7 @@ var React = require("react");
 module.exports = class extends React.Component {
   render() {
     this.test = "test";
-
+    const item = 1;
     return (
       <div>
         <For each="item" of={this.props.items}>

--- a/transform/tests/fixture/for/output.js
+++ b/transform/tests/fixture/for/output.js
@@ -2,6 +2,7 @@ var React = require("react");
 module.exports = class extends React.Component {
     render() {
         this.test = "test";
+        const item = 1;
         return <div>
         {this.props.items.map(function(item, _){
             return <span key={item}>{item + this.test}</span>;


### PR DESCRIPTION
Added `IdentReplacer` to address the inconsistency of variable name ctxt within `For` and `With` tags.

Taking the For tag as an example, in real-world projects such as rspack, simply creating variables based on the name of the `each` attribute does not work as expected. Under hygiene mechanisms, because the context (ctxt) of the `each` variable differs from that of variables inside the children of the For tag, automatic renaming occurs, leading to runtime errors.

Problem:

```jsx
// input.js
<For each="item" index="idx" of={list}>
    <div>{item.xxx}</div>
</For>

// output.js
list.map(function(item1) { // The original item was automatically renamed to item1.
    return item.xxx; // 💥 cause undefined error
})
```

At the same time, some additional tasks were completed:

1. Resolve variable conflicts without `each`, `index`
2. Apply resolver while testing